### PR TITLE
Add 'application/javascript' to nginx gzip types

### DIFF
--- a/nginx/attributes/customize.rb
+++ b/nginx/attributes/customize.rb
@@ -1,5 +1,6 @@
 override[:nginx][:gzip_types] = [
   "application/x-javascript",
+  "application/javascript",
   "application/xhtml+xml",
   "application/xml",
   "application/xml+rss",


### PR DESCRIPTION
This is needed for anyone on Sprockets 3.0 - 3.5, since gzip was removed
from those versions of Sprockets, so we need nginx to do the compression
for this content type. For anyone running an older/newer version of
Sprockets, this is not necessary since Sprockets will gzip and nginx is
configured by default with `gzip_static` which will send precompressed
files with '.gz' extension instead of the regular file.