### PR TITLE
Add ability to configure a nginx `proxy_pass`

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -22,6 +22,15 @@ server {
     return 444;
   }
 
+  <% if @application[:nginx] && @application[:nginx][:proxy_passes] %>
+    <% @application[:nginx][:proxy_passes].each do |proxy| %>
+    location <%= proxy[:location] %> {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass <%= proxy[:upstream] %>;
+    }
+    <% end %>
+  <% end %>
+
   location ~* \.(eot|ttf|woff|ico)$ {
     gzip_static on;
     expires     max;


### PR DESCRIPTION
This change adds the ability to configure simple nginx proxy_pass in
the custom json for an app, by specifying a list of hashes containing a `location` and
an `upstream`.